### PR TITLE
tf2.0.0rc0->tf2.0.0

### DIFF
--- a/docs/0.DonkeyCar3の構築/05.donkey_install.md
+++ b/docs/0.DonkeyCar3の構築/05.donkey_install.md
@@ -118,16 +118,16 @@ wget https://www.piwheels.org/simple/tensorflow/tensorflow-1.13.1-cp37-none-linu
 pip install ./tensorflow-1.13.1-cp37-none-linux_armv7l.whl
 ```
 
-### TensorFlow 2.0.0 RC0の構築
+### TensorFlow 2.0.0の構築
 
-Googleの公式版の[TensorFlowレポジトリ](https://github.com/tensorflow/tensorflow)では、2.0.0に対応していないために、[PINTO0309](https://github.com/PINTO0309)さんがBuildをかけて、公開してくれている2.0.0 RC0をインストールして使用します。
+Googleの公式版の[TensorFlowレポジトリ](https://github.com/tensorflow/tensorflow)では、2.0.0に対応していないために、[PINTO0309](https://github.com/PINTO0309)さんがBuildをかけて、公開してくれている2.0.0をインストールして使用します。
 
 |Package|Version|
 |:--|:--|
-|TensorFlow|2.0.0-RC0|
+|TensorFlow|2.0.0|
 
-TensorFlow 2.0.0-RC0をwgetコマンドで取得します。
+TensorFlow 2.0.0をwgetコマンドで取得します。
 ```
-wget https://github.com/PINTO0309/Tensorflow-bin/raw/master/tensorflow-2.0.0rc0-cp37-cp37m-linux_armv7l.whl
-pip install ./tensorflow-2.0.0rc0-cp37-cp37m-linux_armv7l.whl
+wget https://github.com/PINTO0309/Tensorflow-bin/raw/master/tensorflow-2.0.0-cp37-cp37m-linux_armv7l.whl
+pip install ./tensorflow-2.0.0-cp37-cp37m-linux_armv7l.whl
 ```


### PR DESCRIPTION
tf2.0.0 has been officially released so my repository has been updated. As the repository grows, older versions are expected to be removed soon. If there is no problem, update the procedure to use the latest TF2.0 Wheel file.

**tensorflow-2.0.0rc0-cp37-cp37m-linux_armv7l.whl**
↓
**tensorflow-2.0.0-cp37-cp37m-linux_armv7l.whl**